### PR TITLE
Adjust ignore patterns

### DIFF
--- a/blueprint/backend/files.py
+++ b/blueprint/backend/files.py
@@ -17,8 +17,7 @@ import subprocess
 # The default list of ignore patterns.
 #
 # XXX Update `blueprintignore`(5) if you make changes here.
-IGNORE = ('*.dpkg-dist',
-          '*.dpkg-old',
+IGNORE = ('*.dpkg-*',
           '/etc/.git',
           '/etc/.pwd.lock',
           '/etc/alternatives',

--- a/man/man5/blueprintignore.5.ronn
+++ b/man/man5/blueprintignore.5.ronn
@@ -17,8 +17,7 @@ As part of `blueprint-create`(1), the `~/.blueprintignore` file that was used to
 
 The following files and directories are part of the default ignore list.  They can be negated using `!` just like any other pattern.
 
-* `*.dpkg-dist`
-* `*.dpkg-old`
+* `*.dpkg-*`
 * `/etc/.git`
 * `/etc/.pwd.lock`
 * `/etc/alternatives`


### PR DESCRIPTION
I just played with blueprint and I noticed it included several _.dpkg-_ files like *.dpkg-bak and *.dpkg-new. As these file don't have anything to do with the normal production i think its save to ignore all *.dpkg- files.
