### PR TITLE
Fix some utf-8 errors starting from #9 patch

### DIFF
--- a/blueprint/chef.py
+++ b/blueprint/chef.py
@@ -114,7 +114,10 @@ class Cookbook(object):
             except OSError as e:
                 if errno.EEXIST != e.errno:
                     raise e
-            f = codecs.open(pathname, 'w', 'utf-8')
+            if pathname.endswith('.tar'):
+                f = open(pathname, 'w')
+            else:
+                f = codecs.open(pathname, 'w', 'utf-8')
             f.write(resource.content)
             f.close()
         if gzip:

--- a/blueprint/puppet.py
+++ b/blueprint/puppet.py
@@ -161,7 +161,10 @@ class Manifest(object):
             except OSError as e:
                 if errno.EEXIST != e.errno:
                     raise e
-            f = codecs.open(pathname, 'w', encoding='utf-8')
+            if pathname.endswith('.tar'):
+                f = open(pathname,'w')
+            else:
+                f = codecs.open(pathname, 'w', encoding='utf-8')
             f.write(content)
             f.close()
         if gzip:

--- a/blueprint/sh.py
+++ b/blueprint/sh.py
@@ -53,7 +53,10 @@ class Script(object):
         f.write(self.comment)
         f.write('cd "$(dirname "$0")"\n')
         for filename2, content in sorted(self.sources.iteritems()):
-            f2 = codecs.open(os.path.join(self.name, filename2), 'w', encoding='utf-8')
+            if filename2.endswith('.tar'):
+                f2 = open(os.path.join(self.name,filename2), 'w')
+            else:
+                f2 = codecs.open(os.path.join(self.name, filename2), 'w', encoding='utf-8')
             f2.write(content)
             f2.close()
         for out in self.out:


### PR DESCRIPTION
The utf-8 errors originate from the patch for issue #9 , utf-8 compatibility. That patch attempted to save everything using the codecs module, including the .tar file. I've added a quick "if" check for .tar files so we don't try to use codecs to save a binary file.
There might be a more elegant way to do this, but this gets the script working again.
