### PR TITLE
Rename and merge the blueprint-sortinghat command

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ The HTTP [endpoints](https://devstructure.com/docs/endpoints.html) and [protocol
 * [`blueprint-list`(1)](http://devstructure.github.com/blueprint/blueprint-list.1.html)
 * [`blueprint-create`(1)](http://devstructure.github.com/blueprint/blueprint-create.1.html)
 * [`blueprint-show`(1)](http://devstructure.github.com/blueprint/blueprint-show.1.html)
+* [`blueprint-diff`(1)](http://devstructure.github.com/blueprint/blueprint-diff.1.html)
+* [`blueprint-split`(1)](http://devstructure.github.com/blueprint/blueprint-split.1.html)
 * [`blueprint-apply`(1)](http://devstructure.github.com/blueprint/blueprint-apply.1.html)
 * [`blueprint-push`(1)](http://devstructure.github.com/blueprint/blueprint-push.1.html)
 * [`blueprint-pull`(1)](http://devstructure.github.com/blueprint/blueprint-pull.1.html)

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The HTTP [endpoints](https://devstructure.com/docs/endpoints.html) and [protocol
 * [`blueprint-show`(1)](http://devstructure.github.com/blueprint/blueprint-show.1.html)
 * [`blueprint-diff`(1)](http://devstructure.github.com/blueprint/blueprint-diff.1.html)
 * [`blueprint-split`(1)](http://devstructure.github.com/blueprint/blueprint-split.1.html)
+* [`blueprint-prune`(1)](http://devstructure.github.com/blueprint/blueprint-prune.1.html)
 * [`blueprint-apply`(1)](http://devstructure.github.com/blueprint/blueprint-apply.1.html)
 * [`blueprint-push`(1)](http://devstructure.github.com/blueprint/blueprint-push.1.html)
 * [`blueprint-pull`(1)](http://devstructure.github.com/blueprint/blueprint-pull.1.html)

--- a/bin/blueprint-apply
+++ b/bin/blueprint-apply
@@ -1,14 +1,11 @@
 #!/usr/bin/python
 
-import json
 import logging
 import optparse
 import os
-import re
 import subprocess
 import sys
 
-import blueprint
 import blueprint.cli
 from blueprint import context_managers
 

--- a/bin/blueprint-create
+++ b/bin/blueprint-create
@@ -3,13 +3,8 @@
 import errno
 import logging
 import optparse
-import os
-import re
-import select
-import subprocess
 import sys
 
-import blueprint
 import blueprint.cli
 from blueprint import context_managers
 

--- a/bin/blueprint-destroy
+++ b/bin/blueprint-destroy
@@ -2,7 +2,6 @@
 
 import logging
 import optparse
-import re
 import sys
 
 import blueprint

--- a/bin/blueprint-diff
+++ b/bin/blueprint-diff
@@ -33,7 +33,7 @@ if 3 != len(args):
 minuend, subtrahend, difference = args
 
 try:
-    b_m = blueprint.Blueprint(name=minuend)
+    b_m = blueprint.Blueprint.checkout(minuend)
 except blueprint.NotFoundError:
     logging.error('blueprint {0} does not exist'.format(minuend))
     sys.exit(1)
@@ -41,7 +41,7 @@ except blueprint.NameError:
     logging.error('invalid blueprint name {0}'.format(minuend))
     sys.exit(1)
 try:
-    b_s = blueprint.Blueprint(name=subtrahend)
+    b_s = blueprint.Blueprint.checkout(subtrahend)
 except blueprint.NotFoundError:
     logging.error('blueprint {0} does not exist'.format(subtrahend))
     sys.exit(1)

--- a/bin/blueprint-diff
+++ b/bin/blueprint-diff
@@ -1,10 +1,7 @@
 #!/usr/bin/python
 
-import errno
 import logging
 import optparse
-import re
-import subprocess
 import sys
 
 import blueprint

--- a/bin/blueprint-prune
+++ b/bin/blueprint-prune
@@ -11,8 +11,7 @@ from blueprint import cli
 from blueprint import context_managers
 from blueprint import interactive
 
-parser = optparse.OptionParser(
-    'Usage: %prog [-m <message>] [-q] <src> <dest-a> <dest-b>')
+parser = optparse.OptionParser('Usage: %prog [-m <message>] [-q] <src> <dest>')
 parser.add_option('-m', '--message',
                   dest='message',
                   default=None,
@@ -27,40 +26,31 @@ options, args = parser.parse_args()
 if options.quiet:
     logging.root.setLevel(logging.CRITICAL)
 
-if len(args) not in (2, 3):
+if len(args) not in (1, 2):
     parser.print_usage()
     sys.exit(1)
 
 b_s = blueprint.cli.read(options, args)
 try:
-    b_da = blueprint.Blueprint(args[-2])
-except blueprint.NameError:
-    logging.error('invalid blueprint name {0}'.format(args[-2]))
-    sys.exit(1)
-try:
-    b_db = blueprint.Blueprint(args[-1])
+    b_d = blueprint.Blueprint(args[-1])
 except blueprint.NameError:
     logging.error('invalid blueprint name {0}'.format(args[-1]))
     sys.exit(1)
 
 def choose():
     """
-    Return the blueprint object indicated by the user's input.
+    Return the destination blueprint object or `None`.
     """
-    prompt = '"{0}" or "{1}"? '.format(args[-2], args[-1])
-    prefix = raw_input(prompt)
-    while args[-2].startswith(prefix) == args[-1].startswith(prefix):
-        print('Ambiguous; please give a unique prefix of a blueprint name.')
-        prefix = raw_input(prompt)
-    return {(True, False): b_da,
-            (False, True): b_db}[(args[-2].startswith(prefix),
-                                  args[-1].startswith(prefix))]
+    prompt = 'Include in blueprint {0}? [y/n] '.format(args[-1])
+    yn = raw_input(prompt).lower()
+    while yn not in ('y', 'n', 'yes', 'no'):
+        yn = raw_input(prompt)
+    return b_d if 'y' == yn[0] else None
 
 try:
     with context_managers.mkdtemp():
         interactive.walk(b_s, choose)
-        b_da.commit(options.message or '')
-        b_db.commit(options.message or '')
+        b_d.commit(options.message or '')
 except IOError:
     pass
 except KeyboardInterrupt:

--- a/bin/blueprint-pull
+++ b/bin/blueprint-pull
@@ -6,7 +6,6 @@ import re
 import sys
 import urlparse
 
-import blueprint
 from blueprint import cfg
 from blueprint import context_managers
 import blueprint.io

--- a/bin/blueprint-push
+++ b/bin/blueprint-push
@@ -3,10 +3,8 @@
 from ConfigParser import NoOptionError
 import logging
 import optparse
-import re
 import sys
 
-import blueprint
 from blueprint import cfg
 import blueprint.cli
 import blueprint.io

--- a/bin/blueprint-show
+++ b/bin/blueprint-show
@@ -3,10 +3,8 @@
 import errno
 import logging
 import optparse
-import re
 import sys
 
-import blueprint
 import blueprint.cli
 
 parser = optparse.OptionParser('Usage: %prog [-P|-C|-S|-I] [-r] [-q] [<name>]')

--- a/bin/blueprint-show-files
+++ b/bin/blueprint-show-files
@@ -1,12 +1,9 @@
 #!/usr/bin/python
 
-import errno
 import logging
 import optparse
-import subprocess
 import sys
 
-import blueprint
 import blueprint.cli
 
 parser = optparse.OptionParser('Usage: %prog [-q] [<name>]')

--- a/bin/blueprint-show-ignore
+++ b/bin/blueprint-show-ignore
@@ -1,12 +1,9 @@
 #!/usr/bin/python
 
-import errno
 import logging
 import optparse
-import subprocess
 import sys
 
-import blueprint
 import blueprint.cli
 
 parser = optparse.OptionParser('Usage: %prog [-q] [<name>]')

--- a/bin/blueprint-show-packages
+++ b/bin/blueprint-show-packages
@@ -1,12 +1,9 @@
 #!/usr/bin/python
 
-import errno
 import logging
 import optparse
-import subprocess
 import sys
 
-import blueprint
 import blueprint.cli
 
 parser = optparse.OptionParser('Usage: %prog [-q] [<name>]')

--- a/bin/blueprint-show-services
+++ b/bin/blueprint-show-services
@@ -1,12 +1,9 @@
 #!/usr/bin/python
 
-import errno
 import logging
 import optparse
-import subprocess
 import sys
 
-import blueprint
 import blueprint.cli
 
 parser = optparse.OptionParser('Usage: %prog [-q] [<name>]')

--- a/bin/blueprint-show-sources
+++ b/bin/blueprint-show-sources
@@ -1,12 +1,10 @@
 #!/usr/bin/python
 
-import errno
 import logging
 import optparse
 import subprocess
 import sys
 
-import blueprint
 import blueprint.cli
 from blueprint import git
 

--- a/bin/blueprint-sortinghat
+++ b/bin/blueprint-sortinghat
@@ -1,0 +1,115 @@
+#!/usr/bin/python
+
+import logging
+import optparse
+import readline
+import subprocess
+import sys
+
+import blueprint
+from blueprint import context_managers
+from blueprint import git
+from blueprint import walk
+
+parser = optparse.OptionParser(
+    'Usage: %prog [-m <message>] [-q] <src> <dest-a> <dest-b>')
+parser.add_option('-m', '--message',
+                  dest='message',
+                  default=None,
+                  help='commit message')
+parser.add_option('-q', '--quiet',
+                  dest='quiet',
+                  default=False,
+                  action='store_true',
+                  help='operate quietly')
+options, args = parser.parse_args()
+
+if options.quiet:
+    logging.root.setLevel(logging.CRITICAL)
+
+if 3 != len(args):
+    parser.print_usage()
+    sys.exit(1)
+src, dest_a, dest_b = args
+
+try:
+    b_s = blueprint.Blueprint.checkout(src)
+except blueprint.NotFoundError:
+    logging.error('blueprint {0} does not exist'.format(src))
+    sys.exit(1)
+except blueprint.NameError:
+    logging.error('invalid blueprint name {0}'.format(src))
+    sys.exit(1)
+try:
+    b_da = blueprint.Blueprint(dest_a)
+except blueprint.NameError:
+    logging.error('invalid blueprint name {0}'.format(dest_a))
+    sys.exit(1)
+try:
+    b_db = blueprint.Blueprint(dest_b)
+except blueprint.NameError:
+    logging.error('invalid blueprint name {0}'.format(dest_b))
+    sys.exit(1)
+
+# Return the blueprint object indicated by the user's input.
+
+def sortinghat():
+    prompt = '"{0}" or "{1}"? '.format(dest_a, dest_b)
+    prefix = raw_input(prompt)
+    while dest_a.startswith(prefix) == dest_b.startswith(prefix):
+        print('Ambiguous; please give a unique prefix of a blueprint name.')
+        prefix = raw_input(prompt)
+    return {(True, False): b_da,
+            (False, True): b_db}[(dest_a.startswith(prefix),
+                                  dest_b.startswith(prefix))]
+
+# Call the sorting hat and then add the resource being walked to the blueprint
+# indicated by the sorting hat.
+def file(pathname, f):
+    print(pathname)
+    sortinghat().add_file(pathname, **f)
+def package(manager, package, version):
+    print('{0} {1} {2}'.format(manager, package, version))
+    sortinghat().add_package(manager, package, version)
+def service(manager, service):
+    print('{0} {1}'.format(manager, service))
+    b = sortinghat()
+    b.add_service(manager, service)
+    def service_file(m, s, pathname):
+        b.add_service_file(m, s, pathname)
+    walk.walk_service_files(b, manager, service, service_file=service_file)
+    def service_package(m, s, pm, package):
+        b.add_service_package(m, s, pm, package)
+    walk.walk_service_packages(b,
+                               manager,
+                               service,
+                               service_package=service_package)
+    def service_source(m, s, dirname):
+        b.add_service_source(m, s, dirname)
+    walk.walk_service_sources(b,
+                              manager,
+                              service,
+                              service_source=service_source)
+commit = git.rev_parse(src)
+tree = git.tree(commit)
+def source(dirname, filename, gen_content, url):
+    if url is not None:
+        print('{0} {1}'.format(dirname, url))
+    elif gen_content is not None:
+        blob = git.blob(tree, filename)
+        p = subprocess.Popen(['cat'],
+                             close_fds=True,
+                             stdin=git.cat_file(blob),
+                             stdout=open(filename, 'w'))
+        print('{0} {1}'.format(dirname, filename))
+    sortinghat().add_source(dirname, filename)
+
+try:
+    with context_managers.mkdtemp():
+        b_s.walk(file=file, package=package, service=service, source=source)
+        b_da.commit(options.message or '')
+        b_db.commit(options.message or '')
+except IOError:
+    pass
+except KeyboardInterrupt:
+    print('')

--- a/bin/blueprint-split
+++ b/bin/blueprint-split
@@ -52,8 +52,7 @@ except blueprint.NameError:
     sys.exit(1)
 
 # Return the blueprint object indicated by the user's input.
-
-def sortinghat():
+def choose():
     prompt = '"{0}" or "{1}"? '.format(dest_a, dest_b)
     prefix = raw_input(prompt)
     while dest_a.startswith(prefix) == dest_b.startswith(prefix):
@@ -67,13 +66,13 @@ def sortinghat():
 # indicated by the sorting hat.
 def file(pathname, f):
     print(pathname)
-    sortinghat().add_file(pathname, **f)
+    choose().add_file(pathname, **f)
 def package(manager, package, version):
     print('{0} {1} {2}'.format(manager, package, version))
-    sortinghat().add_package(manager, package, version)
+    choose().add_package(manager, package, version)
 def service(manager, service):
     print('{0} {1}'.format(manager, service))
-    b = sortinghat()
+    b = choose()
     b.add_service(manager, service)
     def service_file(m, s, pathname):
         b.add_service_file(m, s, pathname)
@@ -102,7 +101,7 @@ def source(dirname, filename, gen_content, url):
                              stdin=git.cat_file(blob),
                              stdout=open(filename, 'w'))
         print('{0} {1}'.format(dirname, filename))
-    sortinghat().add_source(dirname, filename)
+    choose().add_source(dirname, filename)
 
 try:
     with context_managers.mkdtemp():

--- a/blueprint/__init__.py
+++ b/blueprint/__init__.py
@@ -3,20 +3,14 @@ from collections import defaultdict
 import copy
 import json
 import logging
-import os
 import os.path
 import re
-import subprocess
-import time
-import urllib
 
 # This must be called early - before the rest of the blueprint library loads.
 logging.basicConfig(format='# [blueprint] %(message)s',
                     level=logging.INFO)
 
-import context_managers
 import git
-import managers
 import util
 
 

--- a/blueprint/backend/__init__.py
+++ b/blueprint/backend/__init__.py
@@ -8,7 +8,6 @@ import glob
 import os.path
 import sys
 
-import blueprint
 
 __all__ = [os.path.basename(filename)[:-3]
            for filename in glob.glob(os.path.join(os.path.dirname(__file__),

--- a/blueprint/backend/gem.py
+++ b/blueprint/backend/gem.py
@@ -6,7 +6,6 @@ import glob
 import logging
 import os
 import re
-import subprocess
 
 from blueprint import util
 from blueprint import ignore

--- a/blueprint/backend/gem.py
+++ b/blueprint/backend/gem.py
@@ -50,4 +50,5 @@ def gem(b):
                     logging.warning('skipping questionably named gem {0}'.
                                     format(entry))
                     continue
-                b.add_package(manager, package, version)
+                if not ignore.package(manager, package):
+                    b.add_package(manager, package, version)

--- a/blueprint/backend/npm.py
+++ b/blueprint/backend/npm.py
@@ -9,7 +9,6 @@ import logging
 import re
 import subprocess
 
-from blueprint import util
 from blueprint import ignore
 
 

--- a/blueprint/backend/npm.py
+++ b/blueprint/backend/npm.py
@@ -28,6 +28,7 @@ def npm(b):
             if match is None:
                 continue
             package, version = match.group(1), match.group(2)
-            b.add_package('nodejs', package, version)
+            if not ignore.package('nodejs', package):
+                b.add_package('nodejs', package, version)
     except OSError:
         pass

--- a/blueprint/backend/php.py
+++ b/blueprint/backend/php.py
@@ -36,4 +36,5 @@ def php(b):
             if match is None:
                 continue
             package, version = match.group(1), match.group(2)
-            b.add_package(manager, package, version)
+            if not ignore.package(manager, package):
+                b.add_package(manager, package, version)

--- a/blueprint/backend/pypi.py
+++ b/blueprint/backend/pypi.py
@@ -94,7 +94,8 @@ def _dpkg_query(b, manager, package, version, entry, pathname):
         versions = b.packages['apt'][manager]
         if stdout not in versions:
             versions.add(stdout)
-        b.add_package(manager, package, version)
+        if not ignore.package(manager, package):
+            b.add_package(manager, package, version)
 
     # This package was installed via `pip`.  Figure out how
     # `pip` was installed and use that as this package's
@@ -107,9 +108,11 @@ def _dpkg_query(b, manager, package, version, entry, pathname):
                              stderr=subprocess.PIPE)
         p.communicate()
         if 0 != p.returncode:
-            b.add_package('pip', package, version)
+            if not ignore.package('pip', package):
+                b.add_package('pip', package, version)
         else:
-            b.add_package('python-pip', package, version)
+            if not ignore.package('python-pip', package):
+                b.add_package('python-pip', package, version)
 
 
 def _rpm(b, manager, package, version, entry, pathname):
@@ -143,7 +146,8 @@ def _rpm(b, manager, package, version, entry, pathname):
         versions = b.packages['yum']['python']
         if stdout not in versions:
             versions.add(stdout)
-        b.add_package('python', package, version)
+        if not ignore.package('python', package):
+            b.add_package('python', package, version)
 
     # This package was installed via `pip`.  Figure out how
     # `pip` was installed and use that as this package's
@@ -156,6 +160,8 @@ def _rpm(b, manager, package, version, entry, pathname):
                              stderr=subprocess.PIPE)
         p.communicate()
         if 0 != p.returncode:
-            b.add_package('pip', package, version)
+            if not ignore.package('pip', package):
+                b.add_package('pip', package, version)
         else:
-            b.add_package('python-pip', package, version)
+            if not ignore.package('python-pip', package):
+                b.add_package('python-pip', package, version)

--- a/blueprint/cli.py
+++ b/blueprint/cli.py
@@ -9,7 +9,7 @@ import os
 import sys
 
 import blueprint
-from blueprint import context_managers
+import context_managers
 
 
 def create(options, args):
@@ -63,7 +63,7 @@ def read(options, args):
         logging.error('blueprint {0} does not exist'.format(name))
         sys.exit(1)
     except blueprint.NameError:
-        logging.error('invalid blueprint name')
+        logging.error('invalid blueprint name {0}'.format(name))
         sys.exit(1)
     logging.error('no blueprint found on standard input')
     sys.exit(1)

--- a/blueprint/cli.py
+++ b/blueprint/cli.py
@@ -27,7 +27,7 @@ def create(options, args):
                         'standard input contains invalid blueprint JSON')
                     sys.exit(1)
             else:
-                b = blueprint.Blueprint(args[0], create=True)
+                b = blueprint.Blueprint.create(args[0])
             b.commit(options.message or '')
             return b
     except blueprint.NameError:
@@ -58,7 +58,7 @@ def read(options, args):
                 logging.error('standard input contains invalid blueprint JSON')
                 sys.exit(1)
         if name is not None:
-            return blueprint.Blueprint(name)
+            return blueprint.Blueprint.checkout(name)
     except blueprint.NotFoundError:
         logging.error('blueprint {0} does not exist'.format(name))
         sys.exit(1)

--- a/blueprint/context_managers.py
+++ b/blueprint/context_managers.py
@@ -1,6 +1,4 @@
-import getpass
 import os
-import os.path
 import shutil
 import tempfile
 

--- a/blueprint/frontend/chef.py
+++ b/blueprint/frontend/chef.py
@@ -5,13 +5,11 @@ Chef code generator.
 import base64
 import codecs
 import errno
-from collections import defaultdict
 import os
 import os.path
 import re
 import tarfile
 
-from blueprint import git
 from blueprint import util
 from blueprint import walk
 

--- a/blueprint/frontend/puppet.py
+++ b/blueprint/frontend/puppet.py
@@ -11,7 +11,6 @@ import os.path
 import re
 import tarfile
 
-from blueprint import git
 from blueprint import util
 from blueprint import walk
 

--- a/blueprint/frontend/sh.py
+++ b/blueprint/frontend/sh.py
@@ -10,8 +10,6 @@ import os.path
 import re
 import tarfile
 
-
-from blueprint import git
 from blueprint import util
 
 

--- a/blueprint/interactive.py
+++ b/blueprint/interactive.py
@@ -1,0 +1,79 @@
+"""
+Interactively walk blueprints.
+"""
+
+import subprocess
+
+import git
+import walk as walklib
+
+
+def walk(b, choose):
+    """
+    Given a function for choosing a `Blueprint` object (based typically on
+    the result of a `raw_input` call within the `choose` function), populate
+    one or more `Blueprint`s closed into `choose`.
+    """
+
+    def file(pathname, f):
+        print(pathname)
+        b_chosen = choose()
+        if b_chosen is None:
+            return
+        b_chosen.add_file(pathname, **f)
+
+    def package(manager, package, version):
+        print('{0} {1} {2}'.format(manager, package, version))
+        b_chosen = choose()
+        if b_chosen is None:
+            return
+        b_chosen.add_package(manager, package, version)
+
+    def service(manager, service):
+        print('{0} {1}'.format(manager, service))
+        b_chosen = choose()
+        if b_chosen is None:
+            return
+        b_chosen.add_service(manager, service)
+
+        def service_file(manager, service, pathname):
+            b_chosen.add_service_file(manager, service, pathname)
+        walklib.walk_service_files(b_chosen,
+                                   manager,
+                                   service,
+                                   service_file=service_file)
+
+        def service_package(manager, service, package_manager, package):
+            b_chosen.add_service_package(manager,
+                                         service,
+                                         package_manager,
+                                         package)
+        walklib.walk_service_packages(b_chosen,
+                                      manager,
+                                      service,
+                                      service_package=service_package) 
+        def service_source(manager, service, dirname):
+            b_chosen.add_service_source(manager, service, dirname)
+        walklib.walk_service_sources(b_chosen,
+                                     manager,
+                                     service,
+                                     service_source=service_source)
+
+    commit = git.rev_parse(b.name)
+    tree = git.tree(commit)
+    def source(dirname, filename, gen_content, url):
+        if url is not None:
+            print('{0} {1}'.format(dirname, url))
+        elif gen_content is not None:
+            blob = git.blob(tree, filename)
+            p = subprocess.Popen(['cat'],
+                                 close_fds=True,
+                                 stdin=git.cat_file(blob),
+                                 stdout=open(filename, 'w'))
+            print('{0} {1}'.format(dirname, filename))
+        b_chosen = choose()
+        if b_chosen is None:
+            return
+        b_chosen.add_source(dirname, filename)
+
+    b.walk(file=file, package=package, service=service, source=source)

--- a/blueprint/io/__init__.py
+++ b/blueprint/io/__init__.py
@@ -1,12 +1,9 @@
-import json
 import logging
 import sys
-import urlparse
 
 from blueprint import cfg
 from blueprint import git
 from blueprint import Blueprint
-from blueprint import context_managers
 import http
 
 

--- a/man/man1/blueprint-create.1
+++ b/man/man1/blueprint-create.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BLUEPRINT\-CREATE" "1" "September 2011" "DevStructure" "Blueprint"
+.TH "BLUEPRINT\-CREATE" "1" "October 2011" "DevStructure" "Blueprint"
 .
 .SH "NAME"
 \fBblueprint\-create\fR \- create a blueprint

--- a/man/man1/blueprint-diff.1.ronn
+++ b/man/man1/blueprint-diff.1.ronn
@@ -22,8 +22,6 @@ blueprint-diff(1) -- save the difference between two blueprints
 
 * `~/.blueprints.git`:
   The local repsitory where blueprints are stored, each on its own branch.
-* `/etc/blueprintignore`, `~/.blueprintignore`:
-  Lists of filename patterns to be ignored when creating blueprints.  See `blueprintignore`(5).
 
 ## THEME SONG
 

--- a/man/man1/blueprint-prune.1
+++ b/man/man1/blueprint-prune.1
@@ -1,16 +1,16 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BLUEPRINT\-SPLIT" "1" "October 2011" "DevStructure" "Blueprint"
+.TH "BLUEPRINT\-PRUNE" "1" "October 2011" "DevStructure" "Blueprint"
 .
 .SH "NAME"
-\fBblueprint\-split\fR \- split one blueprint into two others interactively
+\fBblueprint\-prune\fR \- select a subset of resources interactively
 .
 .SH "SYNOPSIS"
-\fBblueprint split\fR [\fB\-m\fR \fImessage\fR] [\fB\-q\fR] \fIsrc\fR \fIdest\-a\fR \fIdest\-b\fR
+\fBblueprint prune\fR [\fB\-m\fR \fImessage\fR] [\fB\-q\fR] \fIsrc\fR \fIdest\fR
 .
 .SH "DESCRIPTION"
-\fBblueprint\-split\fR interactively splits \fIsrc\fR into \fIdest\-a\fR and \fIdest\-b\fR\. Each resource is presented to the user and the user must indicate which destination blueprint will receive the resource by typing a unique prefix of the destination blueprint\'s name\.
+\fBblueprint\-prune\fR interactively selects a subset of the resources in \fIsrc\fR into \fIdest\fR\. Each resource is presented to the user and the user must indicate whether the resource should be included in \fIdest\fR\.
 .
 .P
 The input provides full \fBreadline\fR(3) support but may not be piped from some other source\.

--- a/man/man1/blueprint-prune.1.ronn
+++ b/man/man1/blueprint-prune.1.ronn
@@ -1,13 +1,13 @@
-blueprint-split(1) -- split one blueprint into two others interactively
-=======================================================================
+blueprint-prune(1) -- select a subset of resources interactively
+================================================================
 
 ## SYNOPSIS
 
-`blueprint split` [`-m` _message_] [`-q`] _src_ _dest-a_ _dest-b_  
+`blueprint prune` [`-m` _message_] [`-q`] _src_ _dest_  
 
 ## DESCRIPTION
 
-`blueprint-split` interactively splits _src_ into _dest-a_ and _dest-b_.  Each resource is presented to the user and the user must indicate which destination blueprint will receive the resource by typing a unique prefix of the destination blueprint's name.
+`blueprint-prune` interactively selects a subset of the resources in _src_ into _dest_.  Each resource is presented to the user and the user must indicate whether the resource should be included in _dest_.
 
 The input provides full `readline`(3) support but may not be piped from some other source.
 

--- a/man/man1/blueprint-split.1
+++ b/man/man1/blueprint-split.1
@@ -1,16 +1,16 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BLUEPRINT\-DIFF" "1" "October 2011" "DevStructure" "Blueprint"
+.TH "BLUEPRINT\-SPLIT" "1" "October 2011" "DevStructure" "Blueprint"
 .
 .SH "NAME"
-\fBblueprint\-diff\fR \- save the difference between two blueprints
+\fBblueprint\-split\fR \- split one blueprint into two others interactively
 .
 .SH "SYNOPSIS"
-\fBblueprint diff\fR [\fB\-m\fR \fImessage\fR] [\fB\-q\fR] \fIminuend\fR \fIsubtrahend\fR \fIdifference\fR
+\fBblueprint split\fR [\fB\-m\fR \fImessage\fR] [\fB\-q\fR] \fIsrc\fR \fIdest\-a\fR \fIdest\-b\fR
 .
 .SH "DESCRIPTION"
-\fBblueprint\-diff\fR saves the difference between the blueprints \fIminuend\fR and \fIsubtrahend\fR as \fIdifference\fR\. Files, package versions, and source tarballs in \fIminuend\fR that either differ from their counterparts in \fIsubtrahend\fR or do not appear at all will be included in \fIdifference\fR\.
+\fBblueprint\-split\fR interactively splits \fIsrc\fR into \fIdest\-a\fR and \fIdest\-b\fR\. Each resource is presented to the user and the user must indicate which destination blueprint will receive the resource by typing a unique prefix of the destination blueprint\'s name\. (The input provides full \fBreadline\fR(3) support\.)
 .
 .SH "OPTIONS"
 .

--- a/man/man1/blueprint-split.1.ronn
+++ b/man/man1/blueprint-split.1.ronn
@@ -1,0 +1,36 @@
+blueprint-split(1) -- split one blueprint into two others interactively
+=======================================================================
+
+## SYNOPSIS
+
+`blueprint split` [`-m` _message_] [`-q`] _src_ _dest-a_ _dest-b_  
+
+## DESCRIPTION
+
+`blueprint-split` interactively splits _src_ into _dest-a_ and _dest-b_.  Each resource is presented to the user and the user must indicate which destination blueprint will receive the resource by typing a unique prefix of the destination blueprint's name.  (The input provides full `readline`(3) support.)
+
+## OPTIONS
+
+* `-m` _message_, `--message=`_message_:
+  Commit message.
+* `-q`, `--quiet`:
+  Operate quietly.
+* `-h`, `--help`:
+  Show a help message.
+
+## FILES
+
+* `~/.blueprints.git`:
+  The local repsitory where blueprints are stored, each on its own branch.
+
+## THEME SONG
+
+The Flaming Lips - "The W.A.N.D. (The Will Always Negates Defeat)"
+
+## AUTHOR
+
+Richard Crowley <richard@devstructure.com>
+
+## SEE ALSO
+
+Part of `blueprint`(1).

--- a/man/man1/blueprint.1
+++ b/man/man1/blueprint.1
@@ -33,6 +33,10 @@ Save the difference between two blueprints\.
 Split one blueprint into two others interactively\.
 .
 .TP
+\fBblueprint\-prune\fR(1)
+Select a subset of resources interactively\.
+.
+.TP
 \fBblueprint\-apply\fR(1)
 Run a blueprint\'s generated shell code\.
 .

--- a/man/man1/blueprint.1
+++ b/man/man1/blueprint.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BLUEPRINT" "1" "September 2011" "DevStructure" "Blueprint"
+.TH "BLUEPRINT" "1" "October 2011" "DevStructure" "Blueprint"
 .
 .SH "NAME"
 \fBblueprint\fR \- reverse engineer server configuration
@@ -23,6 +23,14 @@ Create a blueprint\.
 .TP
 \fBblueprint\-show\fR(1)
 Generate code from a blueprint\.
+.
+.TP
+\fBblueprint\-diff\fR(1)
+Save the difference between two blueprints\.
+.
+.TP
+\fBblueprint\-split\fR(1)
+Split one blueprint into two others interactively\.
 .
 .TP
 \fBblueprint\-apply\fR(1)

--- a/man/man1/blueprint.1.ronn
+++ b/man/man1/blueprint.1.ronn
@@ -19,6 +19,8 @@ blueprint(1) -- reverse engineer server configuration
   Save the difference between two blueprints.
 * `blueprint-split`(1):
   Split one blueprint into two others interactively.
+* `blueprint-prune`(1):
+  Select a subset of resources interactively.
 * `blueprint-apply`(1):
   Run a blueprint's generated shell code.
 * `blueprint-push`(1):

--- a/man/man1/blueprint.1.ronn
+++ b/man/man1/blueprint.1.ronn
@@ -15,6 +15,10 @@ blueprint(1) -- reverse engineer server configuration
   Create a blueprint.
 * `blueprint-show`(1):
   Generate code from a blueprint.
+* `blueprint-diff`(1):
+  Save the difference between two blueprints.
+* `blueprint-split`(1):
+  Split one blueprint into two others interactively.
 * `blueprint-apply`(1):
   Run a blueprint's generated shell code.
 * `blueprint-push`(1):

--- a/man/man7/blueprint.7
+++ b/man/man7/blueprint.7
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BLUEPRINT" "7" "September 2011" "DevStructure" "Blueprint"
+.TH "BLUEPRINT" "7" "October 2011" "DevStructure" "Blueprint"
 .
 .SH "NAME"
 \fBblueprint\fR \- Blueprint Python library
@@ -12,19 +12,20 @@
 
 import blueprint
 
-b = blueprint\.Blueprint(name=\'foo\', create=True)
-b\.commit()
+b1 = blueprint\.Blueprint\.create(\'foo\')
+b1\.commit()
 
-b\.puppet()\.dumpf(gzip=True)
-b\.chef()\.dumpf(gzip=True)
-b\.sh()\.dumpf(gzip=True)
+b2 = blueprint\.Blueprint\.checkout(\'foo\')
+b2\.puppet()\.dumpf(gzip=True)
+b2\.chef()\.dumpf(gzip=True)
+b2\.sh()\.dumpf(gzip=True)
 .
 .fi
 .
 .SH "DESCRIPTION"
 .
 .SS "blueprint\.Blueprint"
-The \fBblueprint\.Blueprint\fR class manages blueprints stored in the local blueprint repository using the \fBgit\fR(1) tools\. New blueprints are created by passing the \fBcreate=True\fR keyword argument to \fBblueprint\.Blueprint\fR\. Previously committed blueprints are referenced by passing the \fBname=\fR\fIname\fR keyword argument and optionally \fBcommit=\fR\fIcommit\fR\.
+The \fBblueprint\.Blueprint\fR class manages blueprints stored in the local blueprint repository using the \fBgit\fR(1) tools\. New blueprints are created by calling the \fBblueprint\.Blueprint\.create\fR class method with a \fIname\fR\. Previously committed blueprints are recalled by calling the \fBblueprint\.Blueprint\.checkout\fR class method with a \fIname\fR and optionally a \fIcommit\fR\. Empty blueprints are created by calling the \fBblueprint\.Blueprint\fR constructor\.
 .
 .P
 \fBblueprint\.Blueprint\fR objects may be subtracted from one another\.
@@ -147,7 +148,7 @@ The \fBblueprint\.Blueprint\fR class (not individual instances) supports \fBdest
 .P
 \fBdumpf(gzip=\fR\fIFalse\fR\fB)\fR returns the name of a file, possibly in a newly\-created directory, containing code in the language implemented by the class that received the call\. The file or directory is created in the current working directory\. If \fBgzip=\fR\fITrue\fR, the file or directory will compressed and the resulting tarball will be left in the current working directory\.
 .
-.SS "blueprint\.manager"
+.SS "blueprint\.managers"
 The \fBblueprint\.managers\.PackageManager\fR class is a \fBunicode\fR subclass that is used as the key in the \fBpackages\fR dictionary\. It is a callable that can translate package names and versions into shell commands for installing the package\. For example: \fBblueprint\.managers\.PackageManager(\fR\fI\'apt\'\fR\fB)(\fR\fI\'python\'\fR\fB,\fR\fI\'2\.6\.6\-2ubuntu1\'\fR\fB)\fR\.
 .
 .P

--- a/man/man7/blueprint.7.ronn
+++ b/man/man7/blueprint.7.ronn
@@ -5,18 +5,19 @@ blueprint(7) -- Blueprint Python library
 
 	import blueprint
 
-	b = blueprint.Blueprint(name='foo', create=True)
-	b.commit()
+	b1 = blueprint.Blueprint.create('foo')
+	b1.commit()
 
-	b.puppet().dumpf(gzip=True)
-	b.chef().dumpf(gzip=True)
-	b.sh().dumpf(gzip=True)
+	b2 = blueprint.Blueprint.checkout('foo')
+	b2.puppet().dumpf(gzip=True)
+	b2.chef().dumpf(gzip=True)
+	b2.sh().dumpf(gzip=True)
 
 ## DESCRIPTION
 
 ### blueprint.Blueprint
 
-The `blueprint.Blueprint` class manages blueprints stored in the local blueprint repository using the `git`(1) tools.  New blueprints are created by passing the `create=True` keyword argument to `blueprint.Blueprint`.  Previously committed blueprints are referenced by passing the `name=`_name_ keyword argument and optionally `commit=`_commit_.
+The `blueprint.Blueprint` class manages blueprints stored in the local blueprint repository using the `git`(1) tools.  New blueprints are created by calling the `blueprint.Blueprint.create` class method with a _name_.  Previously committed blueprints are recalled by calling the `blueprint.Blueprint.checkout` class method with a _name_ and optionally a _commit_.  Empty blueprints are created by calling the `blueprint.Blueprint` constructor.
 
 `blueprint.Blueprint` objects may be subtracted from one another.
 
@@ -88,7 +89,7 @@ The `blueprint.Blueprint` class (not individual instances) supports `destroy(`_n
 
 `dumpf(gzip=`_False_`)` returns the name of a file, possibly in a newly-created directory, containing code in the language implemented by the class that received the call.  The file or directory is created in the current working directory.  If `gzip=`_True_, the file or directory will compressed and the resulting tarball will be left in the current working directory.
 
-### blueprint.manager
+### blueprint.managers
 
 The `blueprint.managers.PackageManager` class is a `unicode` subclass that is used as the key in the `packages` dictionary.  It is a callable that can translate package names and versions into shell commands for installing the package.  For example: `blueprint.managers.PackageManager(`_'apt'_`)(`_'python'_`, `_'2.6.6-2ubuntu1'_`)`.
 


### PR DESCRIPTION
A blueprint is currently a pretty monolithic thing, only really controllable via the `blueprintignore` file.  This new tool provides a user-directed method of splitting one blueprint into two, perhaps a base and a customization.
