### PR TITLE
Differential blueprint-create

### DIFF
--- a/bin/blueprint-create
+++ b/bin/blueprint-create
@@ -8,8 +8,12 @@ import sys
 import blueprint.cli
 from blueprint import context_managers
 
-parser = optparse.OptionParser(
-    'Usage: %prog [-P|-C|-S|-I] [-m <message>] [-r] [-q] <name>')
+parser = optparse.OptionParser('Usage: %prog [-d <subtrahend>] [-P|-C|-S|-I] '
+                               '[-m <message>] [-r] [-q] <name>')
+parser.add_option('-d', '--diff',
+                  dest='subtrahend',
+                  default=None,
+                  help='blueprint to subtract from the generated blueprint')
 parser.add_option('-P', '--puppet',
                   dest='generate',
                   action='store_const',
@@ -29,7 +33,7 @@ parser.add_option('-I', '--ignore',
                   dest='generate',
                   action='store_const',
                   const='ignore',
-                  help='show the blueprint\'s ~/.blueprintignore')
+                  help='show the blueprint\'s blueprintignore(5) rules')
 parser.add_option('-m', '--message',
                   dest='message',
                   default=None,

--- a/blueprint/cli.py
+++ b/blueprint/cli.py
@@ -19,6 +19,7 @@ def create(options, args):
     """
     try:
         with context_managers.mkdtemp():
+
             if not os.isatty(sys.stdin.fileno()):
                 try:
                     b = blueprint.Blueprint.load(sys.stdin, args[0])
@@ -28,8 +29,15 @@ def create(options, args):
                     sys.exit(1)
             else:
                 b = blueprint.Blueprint.create(args[0])
+
+            if options.subtrahend:
+                logging.info('subtracting {0}'.format(options.subtrahend))
+                b_s = blueprint.Blueprint.checkout(options.subtrahend)
+                b = b - b_s
+
             b.commit(options.message or '')
             return b
+
     except blueprint.NameError:
         logging.error('invalid blueprint name')
         sys.exit(1)

--- a/man/man1/blueprint-create.1
+++ b/man/man1/blueprint-create.1
@@ -1,19 +1,22 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BLUEPRINT\-CREATE" "1" "September 2011" "DevStructure" "Blueprint"
+.TH "BLUEPRINT\-CREATE" "1" "October 2011" "DevStructure" "Blueprint"
 .
 .SH "NAME"
 \fBblueprint\-create\fR \- create a blueprint
 .
 .SH "SYNOPSIS"
-\fBblueprint create\fR [\fB\-P\fR|\fB\-C\fR|\fB\-S\fR|\fB\-I\fR] [\fB\-m\fR \fImessage\fR] [\fB\-r\fR] [\fB\-q\fR] \fIname\fR
+\fBblueprint create\fR [\fB\-d\fR \fIsubtrahend\fR] [\fB\-P\fR|\fB\-C\fR|\fB\-S\fR|\fB\-I\fR] [\fB\-m\fR \fImessage\fR] [\fB\-r\fR] [\fB\-q\fR] \fIname\fR
 .
 .SH "DESCRIPTION"
 \fBblueprint\-create\fR creates a list of all installed packages and modified configuration files and stores it in the branch \fIname\fR in the local blueprint repository with the commit \fImessage\fR (if given)\.
 .
 .P
 If standard input is not a TTY, a blueprint is read from standard input rather than created from the system\. See \fBblueprint\fR(5) for the details of the format\.
+.
+.P
+If a \fIsubtrahend\fR is given, it is subtracted from the generated or provided blueprint and the difference is committed as \fIname\fR\.
 .
 .P
 If one of \fB\-\-puppet\fR, \fB\-\-chef\fR, or \fB\-\-sh\fR is given, a Puppet module, a Chef cookbook, or POSIX shell code will be generated, written to a file or directory in the current working directory, and its filename will be printed to \fBstdout\fR\. If \fB\-\-ignore\fR is given, the \fBblueprintignore\fR(5) rules used to create the blueprint will be printed to \fBstdout\fR\.
@@ -31,6 +34,10 @@ Anything installed in \fB/usr/local\fR will be archived and included in the blue
 \fBblueprintignore\fR(5) provides means for ignoring specific files and packages plus treating arbitrary directories as \fB/usr/local\fR is treated\.
 .
 .SH "OPTIONS"
+.
+.TP
+\fB\-d\fR \fIsubtrahend\fR, \fB\-\-diff=\fR\fIsubtrahend\fR
+Blueprint to subtract from the generated blueprint\.
 .
 .TP
 \fB\-P\fR, \fB\-\-puppet\fR

--- a/man/man1/blueprint-create.1.ronn
+++ b/man/man1/blueprint-create.1.ronn
@@ -3,13 +3,15 @@ blueprint-create(1) -- create a blueprint
 
 ## SYNOPSIS
 
-`blueprint create` [`-P`|`-C`|`-S`|`-I`] [`-m` _message_] [`-r`] [`-q`] _name_  
+`blueprint create` [`-d` _subtrahend_] [`-P`|`-C`|`-S`|`-I`] [`-m` _message_] [`-r`] [`-q`] _name_  
 
 ## DESCRIPTION
 
 `blueprint-create` creates a list of all installed packages and modified configuration files and stores it in the branch _name_ in the local blueprint repository with the commit _message_ (if given).
 
 If standard input is not a TTY, a blueprint is read from standard input rather than created from the system.  See `blueprint`(5) for the details of the format.
+
+If a _subtrahend_ is given, it is subtracted from the generated or provided blueprint and the difference is committed as _name_.
 
 If one of `--puppet`, `--chef`, or `--sh` is given, a Puppet module, a Chef cookbook, or POSIX shell code will be generated, written to a file or directory in the current working directory, and its filename will be printed to `stdout`.  If `--ignore` is given, the `blueprintignore`(5) rules used to create the blueprint will be printed to `stdout`.
 
@@ -23,6 +25,8 @@ Anything installed in `/usr/local` will be archived and included in the blueprin
 
 ## OPTIONS
 
+* `-d` _subtrahend_, `--diff=`_subtrahend_:
+  Blueprint to subtract from the generated blueprint.
 * `-P`, `--puppet`:
   Generate a Puppet module.
 * `-C`, `--chef`:


### PR DESCRIPTION
This adds the `--diff` option to `blueprint-create` which supports creating blueprints relative to another one.  Specifically, the blueprint named by the `--diff` option is subtracted from the newly created blueprint before it is committed as usual.  Using a base blueprint as the `--diff` would allow the evolution of a customization on top of it (and vice versa, though this is a bit tougher to reason about).
