### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Prerequisites:
 * Python >= 2.6
 * Git >= 1.7
 
-### From source on Debian, Ubuntu, and Fedora
+### From source on Debian, Ubuntu, Fedora, CentOS 6, and RHEL 6
 
 	git clone git://github.com/devstructure/blueprint.git
 	cd blueprint
@@ -77,7 +77,9 @@ Prerequisites:
 	rpm -Uvh http://download.fedora.redhat.com/pub/epel/5/i386/epel-release-5-4.noarch.rpm
 	yum install python26
 	git clone git://github.com/devstructure/blueprint.git
-	cd blueprint && make && sudo make install PYTHON=/usr/bin/python26
+	cd blueprint
+	git submodule update --init
+	make && sudo make install PYTHON=/usr/bin/python26
 
 This installs Python 2.6 from EPEL side-by-side with Python 2.4 and so won't break yum.
 


### PR DESCRIPTION
The installation instructions were a bit outdated. Here is a commit to bring them more inline with the [online docs](http://devstructure.github.com/blueprint/).
