### PR TITLE
fix for mult-arch enabled systems

### DIFF
--- a/blueprint/backend/apt.py
+++ b/blueprint/backend/apt.py
@@ -14,10 +14,9 @@ def apt(b, r):
     # Try for the full list of packages.  If this fails, don't even
     # bother with the rest because this is probably a Yum/RPM-based
     # system.
+    output_format = '${Status}\x1E${binary:Package}\x1E${Version}\n'
     try:
-        p = subprocess.Popen(['dpkg-query',
-                              '-f=${Status}\x1E${binary:Package}\x1E${Version}\n',
-                              '-W'],
+        p = subprocess.Popen(['dpkg-query','-Wf',output_format],
                              close_fds=True, stdout=subprocess.PIPE)
     except OSError:
         return

--- a/blueprint/backend/apt.py
+++ b/blueprint/backend/apt.py
@@ -16,7 +16,7 @@ def apt(b, r):
     # system.
     try:
         p = subprocess.Popen(['dpkg-query',
-                              '-f=${Status}\x1E${Package}\x1E${Version}\n',
+                              '-f=${Status}\x1E${binary:Package}\x1E${Version}\n',
                               '-W'],
                              close_fds=True, stdout=subprocess.PIPE)
     except OSError:


### PR DESCRIPTION
this does not work for systems that are not multi-arch aware, just tested on a Debian Squeeze install, dpkg-query doesn't recognize 'binary:Package' so a test is needed to see if 'dpkg --print-foreign-architecture' is successful, retval 0

Debian has added multi-arch support so you can install packages for other
architectures, and when enabled, packages are differentiated by
'packagename:arch'

The dpkg-query format string '${Package}' displays a short-name, where
'${binary:Package}' displays the architecture 'tag'
