### PR TITLE
Debian multi-arch support fix

### DIFF
--- a/blueprint/backend/apt.py
+++ b/blueprint/backend/apt.py
@@ -2,6 +2,7 @@
 Search for `apt` packages to include in the blueprint.
 """
 
+import os
 import logging
 import subprocess
 
@@ -16,16 +17,17 @@ def apt(b, r):
 
     # try running dpkg --print-foreign-architectures to see if dpkg is
     # multi-arch aware. if not, revert to old style output_format
-    rv = subprocess.call(['dpkg', '--print-foreign-architectures'],
-                            stdout=FNULL, stderr=subprocess.STDOUT)
-    if rv != 0:
-        output_format = '${Status}\x1E${Package}\x1E${Version}\n'
+    with open(os.devnull, 'w') as fnull:
+        rv = subprocess.call(['dpkg', '--print-foreign-architectures'],
+                                stdout = fnull, stderr = fnull)
+        if rv != 0:
+            output_format = '${Status}\x1E${Package}\x1E${Version}\n'
 
     # Try for the full list of packages.  If this fails, don't even
     # bother with the rest because this is probably a Yum/RPM-based
     # system.
     try:
-        p = subprocess.Popen(['dpkg-query','-Wf',output_format],
+        p = subprocess.Popen(['dpkg-query','-Wf', output_format],
                              close_fds=True, stdout=subprocess.PIPE)
     except OSError:
         return

--- a/blueprint/backend/apt.py
+++ b/blueprint/backend/apt.py
@@ -17,7 +17,7 @@ def apt(b, r):
     # try running dpkg --print-foreign-architectures to see if dpkg is
     # multi-arch aware. if not, revert to old style output_format
     rv = subprocess.call(['dpkg', '--print-foreign-architectures'],
-                        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                            stdout=FNULL, stderr=subprocess.STDOUT)
     if rv != 0:
         output_format = '${Status}\x1E${Package}\x1E${Version}\n'
 

--- a/blueprint/backend/apt.py
+++ b/blueprint/backend/apt.py
@@ -11,10 +11,19 @@ from blueprint import util
 def apt(b, r):
     logging.info('searching for APT packages')
 
+    # define a default output format string for dpkg-query
+    output_format = '${Status}\x1E${binary:Package}\x1E${Version}\n'
+
+    # try running dpkg --print-foreign-architectures to see if dpkg is
+    # multi-arch aware. if not, revert to old style output_format
+    rv = subprocess.call(['dpkg', '--print-foreign-architectures'],
+                        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if rv != 0:
+        output_format = '${Status}\x1E${Package}\x1E${Version}\n'
+
     # Try for the full list of packages.  If this fails, don't even
     # bother with the rest because this is probably a Yum/RPM-based
     # system.
-    output_format = '${Status}\x1E${binary:Package}\x1E${Version}\n'
     try:
         p = subprocess.Popen(['dpkg-query','-Wf',output_format],
                              close_fds=True, stdout=subprocess.PIPE)

--- a/blueprint/backend/apt.py
+++ b/blueprint/backend/apt.py
@@ -14,10 +14,9 @@ def apt(b, r):
     # Try for the full list of packages.  If this fails, don't even
     # bother with the rest because this is probably a Yum/RPM-based
     # system.
+    output_format = '${Status}\x1E${binary:Package}\x1E${Version}\n'
     try:
-        p = subprocess.Popen(['dpkg-query',
-                              '-f=${Status}\x1E${binary:Package}\x1E${Version}\n',
-                              '-W'],
+        p = subprocess.Popen(['dpkg-query','-Wf',output_format],
                              close_fds=True, stdout=subprocess.PIPE)
     except OSError:
         return

--- a/blueprint/backend/apt.py
+++ b/blueprint/backend/apt.py
@@ -16,7 +16,7 @@ def apt(b, r):
     # system.
     try:
         p = subprocess.Popen(['dpkg-query',
-                              '-f=${Status}\x1E${Package}\x1E${Version}\n',
+                              '-f=${Status}\x1E${binary:Package}\x1E${Version}\n',
                               '-W'],
                              close_fds=True, stdout=subprocess.PIPE)
     except OSError:


### PR DESCRIPTION
In Debian Squeeze and previous, 'dpkg --print-foreign-architectures' fails and can be used to check for multi-arch.

If 'dpkg --print-foreign-architectures' fails, the format string should be 'Package' and when it succeeds, 'binary:Package' is used instead.

Tested on Debian Squeeze, Debian Wheezy and Ubuntu 13.04
