### PR TITLE
MongoDB support for storage

### DIFF
--- a/blueprint/io/__init__.py
+++ b/blueprint/io/__init__.py
@@ -14,7 +14,6 @@ def pull(server, secret, name):
     r = http.get('/{0}/{1}'.format(secret, name), server=server)
     if 200 == r.status:
         b = Blueprint.load(r, name)
-
         for filename in b.sources.itervalues():
             logging.info('fetching source tarballs - this may take a while')
             r = http.get('/{0}/{1}/{2}'.format(secret, name, filename),

--- a/blueprint/io/http.py
+++ b/blueprint/io/http.py
@@ -11,7 +11,7 @@ def _connect(server=None):
         server = cfg.get('io', 'server')
     url = urlparse.urlparse(server)
     if -1 == url.netloc.find(':'):
-        port = url.port or 443 if 'https' == url.scheme else 80
+        port = url.port
     else:
         port = None
     if 'https' == url.scheme:

--- a/blueprint/io/http.py
+++ b/blueprint/io/http.py
@@ -11,7 +11,7 @@ def _connect(server=None):
         server = cfg.get('io', 'server')
     url = urlparse.urlparse(server)
     if -1 == url.netloc.find(':'):
-        port = url.port
+        port = url.port or 443 if 'https' == url.scheme else 80
     else:
         port = None
     if 'https' == url.scheme:

--- a/blueprint/io/server/__init__.py
+++ b/blueprint/io/server/__init__.py
@@ -22,7 +22,6 @@ else:
 
 app = Flask(__name__)
 
-
 def _blueprint(secret, name):
     """
     Fetch a blueprint from S3 and turn it into a real Blueprint object.
@@ -120,6 +119,12 @@ def secret():
 
 browser_pattern = re.compile(r'Chrome|Gecko|Microsoft|Mozilla|Safari|WebKit')
 
+@app.route('/<secret>/<name>/blueprint.json', methods=['GET'])
+def get_json(secret, name):
+    validate_secret(secret)
+    validate_name(name)
+
+    return backend.get(backend.key_for_blueprint(secret, name))
 
 @app.route('/<secret>/<name>', methods=['GET'])
 def get_blueprint(secret, name):

--- a/blueprint/io/server/__init__.py
+++ b/blueprint/io/server/__init__.py
@@ -9,7 +9,7 @@ import urlparse
 
 from blueprint import Blueprint
 from blueprint import cfg
-import backend
+import backend_mongodb as backend
 import librato
 import statsd
 
@@ -101,12 +101,7 @@ def validate_content_length():
 
 @app.route('/secret', methods=['GET'])
 def secret():
-    while 1:
-        s = base64.urlsafe_b64encode(os.urandom(48))
-        try:
-            iter(backend.list(s)).next()
-        except StopIteration:
-            break
+    s = base64.urlsafe_b64encode(os.urandom(48))
     return MeteredResponse(response='{0}\n'.format(s),
                            status=201,
                            content_type='text/plain')
@@ -274,4 +269,4 @@ sh "$(ls)"
 
 
 if '__main__' == __name__:
-    app.run(host='0.0.0.0', debug=True)
+    app.run(host='0.0.0.0', debug=True, threaded=True)

--- a/blueprint/io/server/backend_mongodb.py
+++ b/blueprint/io/server/backend_mongodb.py
@@ -1,0 +1,144 @@
+from pymongo import MongoClient
+import httplib
+import socket
+
+from blueprint import cfg
+import librato
+import statsd
+
+#pip install pymongo
+
+address = cfg.get('mongodb', 'address')
+port = cfg.get('mongodb', 'port')
+database = cfg.get('mongodb', 'database')
+collection = cfg.get('mongodb', 'collection')
+
+client = MongoClient(address, int(port))
+db = client[database]
+collection = db[collection]
+
+class StoredObject:
+	key = None
+	tarball = None
+	def __init__(self, key, tarball):
+		self.key = key
+		self.tarball = tarball
+
+def delete(key):
+    """
+    Remove an object from S3.  DELETE requests are free but this function
+    still makes one billable request to account for freed storage.
+    """
+    content_length = head(key)
+    if content_length is None:
+        return None
+    librato.count('blueprint-io-server.requests.delete')
+    statsd.increment('blueprint-io-server.requests.delete')
+    collection.delete({"key" : key})
+
+
+def delete_blueprint(secret, name):
+    return delete(key_for_blueprint(secret, name))
+
+
+def delete_tarball(secret, name, sha):
+    return delete(key_for_tarball(secret, name, sha))
+
+
+def get(key):
+    """
+    Fetch an object from S3.  This function makes one billable request.
+    """
+    librato.count('blueprint-io-server.requests.get')
+    statsd.increment('blueprint-io-server.requests.get')
+    k = collection.find_one({"key" : key})
+    if k is None:
+    	return False
+    return k.tarball
+
+
+def get_blueprint(secret, name):
+    return get(key_for_blueprint(secret, name))
+
+
+def get_tarball(secret, name, sha):
+    return get(key_for_tarball(secret, name, sha))
+
+
+def head(key):
+    """
+    Make a HEAD request for an object in S3.  This is needed to find the
+    object's length so it can be accounted.  This function makes one
+    billable request and anticipates another.
+    """
+    librato.count('blueprint-io-server.requests.head')
+    statsd.increment('blueprint-io-server.requests.head')
+    k = collection.find_one({"key" : key})
+    if k is None:
+      	return None
+    return len(k.tarball)
+
+
+def head_blueprint(secret, name):
+    return head(key_for_blueprint(secret, name))
+
+
+def head_tarball(secret, name, sha):
+    return head(key_for_tarball(secret, name, sha))
+
+
+def key_for_blueprint(secret, name):
+    return '{0}/{1}/{2}'.format(secret,
+                                name,
+                                'blueprint.json')
+
+
+def key_for_tarball(secret, name, sha):
+    return '{0}/{1}/{2}.tar'.format(secret,
+                                    name,
+                                    sha)
+
+
+def list(key):
+    """
+    List objects in S3 whose keys begin with the given prefix.  This
+    function makes at least one billable request.
+    """
+    librato.count('blueprint-io-server.requests.list')
+    statsd.increment('blueprint-io-server.requests.list')
+    result = collection.find({"key" : '^%s' % (key)})
+    return list(result)
+
+
+def put(key, data):
+    """
+    Store an object in S3.  This function makes one billable request.
+    """
+    librato.count('blueprint-io-server.requests.put')
+    statsd.increment('blueprint-io-server.requests.put')
+    # TODO librato.something('blueprint-io-server.storage', len(data))
+    statsd.update('blueprint-io-server.storage', len(data))
+    element = StoredObject(key, data)
+    collection.insert(element.__dict__)
+    return True
+
+
+
+def put_blueprint(secret, name, data):
+    return put(key_for_blueprint(secret, name), data)
+
+
+def put_tarball(secret, name, sha, data):
+    return put(key_for_tarball(secret, name, sha), data)
+
+
+def url_for(key):
+    return ''
+
+
+def url_for_blueprint(secret, name):
+    return url_for(key_for_blueprint(secret, name))
+
+
+def url_for_tarball(secret, name, sha):
+    return url_for(key_for_tarball(secret, name, sha))

--- a/blueprint/io/server/backend_mongodb.py
+++ b/blueprint/io/server/backend_mongodb.py
@@ -6,17 +6,26 @@ from blueprint import cfg
 import librato
 import statsd
 
-#pip install pymongo
+username = None
+password = None
 
 address = cfg.get('mongodb', 'address')
 port = cfg.get('mongodb', 'port')
-protocol = 'https' if cfg.getboolean('server', 'use_https') else 'http'
 database = cfg.get('mongodb', 'database')
 collection = cfg.get('mongodb', 'collection')
 url = cfg.get('server', 'address')
+protocol = 'https' if cfg.getboolean('server', 'use_https') else 'http'
+try:
+    username = cfg.get('mongodb', 'user')
+    password = cfg.get('mongodb', 'password')
+except:
+    pass
 
 client = MongoClient(address, int(port))
 db = client[database]
+if username is not None:
+    if password is not None:
+        db.authenticate(username, password)
 collection = db[collection]
 
 class StoredObject:


### PR DESCRIPTION
Hello,

I've been using blueprint for quite a while now and felt like trying out the server but I found out it only supports S3 as a backend for storage.

Using pymongo I've added support for MongoDB in the server backend as a quick personnal project.
# Requirements (on top of existing ones):

```
sudo pip install pymongo
```
# Configuration:

Server side /etc/blueprint.cfg

```
[server]
backend = mongodb # mongodb or s3
address = localhost:5000 # address of your blueprint server
use_https = False # indicates if we should craft url with https or not
[mongodb] 
address = localhost # your MongoDB server address
port = 27017 # your MongoDB server port
collection = blueprint_tarballs # your MongoDB collection
database = blueprint # your MongoDB database
user = myuser # your MongoDB user with access to DB (optionnal)
password = mypassword # your MongoDB user password (optionnal)
```

Client side /etc/blueprint.cfg

```
[io]
server = http://localhost:5000
secret = mysuperverylongsecret
```
