### PR TITLE
List PEAR packages from all registered channels

### DIFF
--- a/blueprint/backend/php.py
+++ b/blueprint/backend/php.py
@@ -26,7 +26,7 @@ def php(b, r):
                               (pecl_manager, 'pecl')):
 
         try:
-            p = subprocess.Popen([progname, 'list'],
+            p = subprocess.Popen([progname, 'list', '-a'],
                                  close_fds=True, stdout=subprocess.PIPE)
         except OSError:
             continue


### PR DESCRIPTION
This trivial patch allows the PEAR package regular expression matcher to catch packages from all registered PEAR channels. I encountered this as an issue when trying to track the installation of Horde packages (http://www.horde.org/), which were mysteriously missing. Turns out that blueprint only issues a `pear list` which captures only the default channel at pear.php.net. To get all registered channels for PEAR packages, we need `pear list -a`.
