### PR TITLE
Fix cache file creation on CentOS 7

### DIFF
--- a/blueprint/deps.py
+++ b/blueprint/deps.py
@@ -74,7 +74,10 @@ def yum(s):
             except OSError:
                 continue
             for line in p.stdout:
-                cap = line.rstrip()[0:line.find(' ')]
+                if line.find(' ') > -1:
+                    cap = line.rstrip()[0:line.find(' ')]
+                else:
+                    cap = line.rstrip()
                 if 'rpmlib' == cap[0:6]:
                     continue
                 try:

--- a/blueprint/rules.py
+++ b/blueprint/rules.py
@@ -221,7 +221,7 @@ def _yum():
 
     # Start with a few groups that install common packages.
     s = set(['gpg-pubkey'])
-    pattern = re.compile(r'^   (\S+)')
+    pattern = re.compile(r'^   (?: |\+)?(\S+)')
     try:
         p = subprocess.Popen(['yum', 'groupinfo',
                               'core','base', 'gnome-desktop'],


### PR DESCRIPTION
With CentOS 7, the output format of "yum groupinfo" and "rpm -q" has changed slightly. This causes a failure when blueprint parses the the output during cache file creation (blueprintignore and blueprint-yum-exclusions).

This pull request fixes:
* parsing of "yum groupinfo" output
Package names may start with a '+' sign, preceeded by 3 or 4 spaces

* paring of "rpm-qR":
Prior to CentOS 7, all returned lines did include spaces (possibly located at the end of the line). With CentOS 7, no more trailing spaces are printed, causing the expression "line.rstrip()[0:line.find(' ')]" to fail for such line (stripping off the last character)

